### PR TITLE
Upgrade AUDIT_INSTRUCTIONS.md to A+ standard

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,5 +1,9 @@
 # Architecture
 
+## Purpose
+
+Juicebox V6 is an onchain programmable treasury protocol for Ethereum. Projects use it to accept payments, issue tokens along a bonding curve, distribute payouts to preset splits, and let token holders cash out their share of surplus — all governed by time-bound rulesets that the project owner queues in advance. The protocol is designed around a small, audited core (terminals, controllers, rulesets, token accounting) that exposes hook interfaces at every decision point, so that features like NFT tiers, DEX buybacks, cross-chain bridging, and autonomous revenue networks are implemented as composable extensions rather than baked into the core contracts.
+
 ## Ecosystem Layers
 
 ```
@@ -255,3 +259,17 @@ See [SKILLS.md](./SKILLS.md#contract-sizes) for per-contract line counts.
 | nana-fee-project-deployer-v6 | Fee project | Deploy.s.sol (script only) |
 | nana-address-registry-v6 | Registry | JBAddressRegistry |
 | nana-permission-ids-v6 | Constants | JBPermissionIds |
+
+## Design Decisions
+
+- **Layered hook composition over monolithic features.** The core protocol deliberately knows nothing about NFTs, buybacks, LP positions, or cross-chain bridging. Every feature is an external hook that plugs into one of six well-defined extension points (data hook, pay hook, cash out hook, split hook, approval hook, deployer). This keeps the audited surface small and lets anyone ship new functionality without modifying or redeploying the core.
+
+- **Data hooks separated from pay/cashout hooks.** Data hooks (`IJBRulesetDataHook`) run as `view` calls *before* the terminal records a transaction, so they can safely override economic parameters (weight, cash out tax rate, total supply) without holding funds. Pay and cash out hooks (`IJBPayHook`, `IJBCashOutHook`) run *after* the terminal has already settled state (updated balances, minted or burned tokens), so they receive funds and execute side effects like minting NFTs or performing swaps. This before/after split means a single data hook can orchestrate multiple downstream hooks via hook specifications, and the core never transfers funds to a contract that is also deciding how much to mint.
+
+- **Ruleset-based governance instead of admin functions.** Project parameters (weight, payout limits, cash out tax rate, hook addresses, permission flags) are bundled into immutable rulesets that activate on a schedule. Once a ruleset is active it cannot be changed — the owner can only queue a *future* ruleset. This gives contributors a guaranteed window to inspect upcoming changes and exit (cash out) before they take effect, without requiring a separate timelock contract.
+
+- **Terminal/store separation for bookkeeping isolation.** `JBMultiTerminal` handles fund custody, access control, fee processing, and hook execution. `JBTerminalStore` handles all arithmetic — balances, surplus calculation, payout limit tracking, bonding curve math. Because the store never holds funds or makes external calls, its logic can be reasoned about (and formally verified) in isolation from reentrancy concerns.
+
+- **Compositional deployers over inheritance.** Higher-level products (revnets, Croptop, Defifa) are thin deployer contracts that wire together core primitives and hooks, rather than subclasses of the core. `REVDeployer` configures a project with specific rulesets, a buyback data hook, and split rules — but it delegates all runtime behavior to the same `JBController` and `JBMultiTerminal` that every other project uses. This means the core protocol's security properties hold uniformly regardless of which deployer created a project.
+
+- **Noop hook specifications for preview transparency.** Data hooks can return hook specifications marked `noop = true`, which the terminal skips during execution but still surfaces in `previewPayFrom` / `previewCashOutFrom` results. This lets hooks like the buyback hook communicate routing diagnostics (TWAP price, pool liquidity, which path won) to frontends without introducing a separate query interface or requiring off-chain indexing.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -104,6 +104,33 @@ Holder → JBMultiTerminal.cashOutTokensOf()
            └──→ Take fees (2.5% to project #1)
 ```
 
+### Preview Flow
+```
+Frontend → JBMultiTerminal.previewPayFor()
+             │
+             ├──→ JBTerminalStore.previewPayFrom()
+             │      ├── Read current ruleset
+             │      ├── [Optional] Data hook overrides weight
+             │      ├── Calculate token count from weight
+             │      └── Return hook specifications (active or noop)
+             │
+             └──→ JBController.previewMintOf()
+                    └── Split token count into beneficiary + reserved
+
+Frontend → JBMultiTerminal.previewCashOutFrom()
+             │
+             └──→ JBTerminalStore.previewCashOutFrom()
+                    ├── Calculate surplus
+                    ├── Get totalSupply (including pending reserved)
+                    ├── [Optional] Data hook overrides parameters
+                    ├── JBCashOuts.cashOutFrom() — bonding curve
+                    └── Return reclaim amount, tax rate, hook specifications
+```
+
+Both are `view` functions — no state changes. Hook specifications may include
+noop specs (informational-only, `noop = true`) carrying routing diagnostics
+from data hooks like the buyback hook.
+
 ### Payout Flow
 ```
 Owner → JBMultiTerminal.sendPayoutsOf()
@@ -156,11 +183,36 @@ Juicebox V6 uses a compositional hook system where features plug into the core p
 | Extension Point | Interface | Called By | Examples |
 |----------------|-----------|-----------|----------|
 | Data Hook (pay) | `IJBRulesetDataHook.beforePayRecordedWith` | JBTerminalStore | JBBuybackHook, REVDeployer |
-| Data Hook (cashout) | `IJBRulesetDataHook.beforeCashOutRecordedWith` | JBTerminalStore | JBOmnichainDeployer, REVDeployer |
-| Pay Hook | `IJBPayHook.afterPayRecordedWith` | JBMultiTerminal | JB721TiersHook |
-| Cash Out Hook | `IJBCashOutHook.afterCashOutRecordedWith` | JBMultiTerminal | JB721TiersHook, REVDeployer, DefifaHook |
+| Data Hook (cashout) | `IJBRulesetDataHook.beforeCashOutRecordedWith` | JBTerminalStore | JBBuybackHook, JBOmnichainDeployer, REVDeployer |
+| Pay Hook | `IJBPayHook.afterPayRecordedWith` | JBMultiTerminal | JB721TiersHook, JBBuybackHook |
+| Cash Out Hook | `IJBCashOutHook.afterCashOutRecordedWith` | JBMultiTerminal | JB721TiersHook, JBBuybackHook, REVDeployer, DefifaHook |
 | Split Hook | `IJBSplitHook.processSplitWith` | JBMultiTerminal | JBUniswapV4LPSplitHook |
 | Approval Hook | `IJBRulesetApprovalHook.approvalStatusOf` | JBRulesets | JBDeadline |
+
+Data hooks return hook specifications that can be marked **noop** (`noop = true`). Noop specs are informational-only — the terminal skips the hook callback but the spec's metadata is still available to preview clients. The buyback hook uses this to return routing diagnostics (TWAP tick, liquidity, pool ID) even when the protocol path wins. Noop specs with `amount != 0` revert (`JBTerminalStore_NoopHookSpecHasAmount`).
+
+#### Hook Composition Flow
+
+```
+Data Hook (beforePayRecordedWith / beforeCashOutRecordedWith)
+│
+├── Returns: modified weight/tax rate/supply
+│   (these overrides are ALWAYS applied)
+│
+└── Returns: hook specifications[]
+    │
+    ├── spec.noop = false, spec.amount > 0
+    │   └── Terminal calls hook.afterPayRecordedWith / afterCashOutRecordedWith
+    │       (active callback — hook receives funds and executes logic)
+    │
+    ├── spec.noop = true, spec.amount = 0
+    │   └── Terminal SKIPS callback
+    │       (informational — metadata available to preview clients only)
+    │
+    └── spec.noop = true, spec.amount > 0
+        └── REVERTS: JBTerminalStore_NoopHookSpecHasAmount
+            (noop specs cannot carry funds)
+```
 
 ### Permission System
 
@@ -182,22 +234,24 @@ JBPermissions (256-bit packed)
 
 ## Repository Summary
 
-| Repository | Role | Key Contracts | LoC |
-|-----------|------|---------------|-----|
-| nana-core-v6 | Core protocol | JBMultiTerminal, JBController, JBTerminalStore, JBRulesets | ~11,200 |
-| nana-suckers-v6 | Cross-chain | JBSucker, JBOptimismSucker, JBBaseSucker, JBArbitrumSucker, JBCCIPSucker | ~5,000 |
-| nana-721-hook-v6 | NFT tiers | JB721TiersHook, JB721TiersHookStore | ~5,100 |
-| defifa-collection-deployer-v6 | Prediction games | DefifaDeployer, DefifaHook, DefifaGovernor, DefifaHookLib | ~3,900 |
-| revnet-core-v6 | Autonomous projects | REVDeployer, REVLoans | ~3,400 |
-| nana-router-terminal-v6 | Payment routing | JBRouterTerminal, JBRouterTerminalRegistry | ~2,200 |
-| nana-buyback-hook-v6 | DEX buyback | JBBuybackHook, JBBuybackHookRegistry, JBSwapLib | ~1,900 |
-| deploy-all-v6 | Ecosystem deployment | Deploy.s.sol (Sphinx orchestration) | ~1,600 |
-| banny-retail-v6 | Banny NFTs | Banny721TokenUriResolver | ~1,600 |
-| univ4-lp-split-hook-v6 | LP management | JBUniswapV4LPSplitHook | ~1,600 |
-| croptop-core-v6 | NFT publishing | CTDeployer, CTPublisher | ~1,400 |
-| univ4-router-v6 | UniV4 integration | JBUniswapV4Hook | ~1,400 |
-| nana-omnichain-deployers-v6 | Omnichain | JBOmnichainDeployer | ~1,000 |
-| nana-ownable-v6 | JB ownership | JBOwnable | ~400 |
-| nana-fee-project-deployer-v6 | Fee project | Deploy.s.sol (script only) | ~200 |
-| nana-address-registry-v6 | Registry | JBAddressRegistry | ~150 |
-| nana-permission-ids-v6 | Constants | JBPermissionIds | ~70 |
+See [SKILLS.md](./SKILLS.md#contract-sizes) for per-contract line counts.
+
+| Repository | Role | Key Contracts |
+|-----------|------|---------------|
+| nana-core-v6 | Core protocol | JBMultiTerminal, JBController, JBTerminalStore, JBRulesets |
+| nana-suckers-v6 | Cross-chain | JBSucker, JBOptimismSucker, JBBaseSucker, JBArbitrumSucker, JBCCIPSucker |
+| nana-721-hook-v6 | NFT tiers | JB721TiersHook, JB721TiersHookStore |
+| defifa-collection-deployer-v6 | Prediction games | DefifaDeployer, DefifaHook, DefifaGovernor, DefifaHookLib |
+| revnet-core-v6 | Autonomous projects | REVDeployer, REVLoans |
+| nana-router-terminal-v6 | Payment routing | JBRouterTerminal, JBRouterTerminalRegistry |
+| nana-buyback-hook-v6 | DEX buyback | JBBuybackHook, JBBuybackHookRegistry, JBSwapLib |
+| deploy-all-v6 | Ecosystem deployment | Deploy.s.sol (Sphinx orchestration) |
+| banny-retail-v6 | Banny NFTs | Banny721TokenUriResolver |
+| univ4-lp-split-hook-v6 | LP management | JBUniswapV4LPSplitHook |
+| croptop-core-v6 | NFT publishing | CTDeployer, CTPublisher |
+| univ4-router-v6 | UniV4 integration | JBUniswapV4Hook |
+| nana-omnichain-deployers-v6 | Omnichain | JBOmnichainDeployer |
+| nana-ownable-v6 | JB ownership | JBOwnable |
+| nana-fee-project-deployer-v6 | Fee project | Deploy.s.sol (script only) |
+| nana-address-registry-v6 | Registry | JBAddressRegistry |
+| nana-permission-ids-v6 | Constants | JBPermissionIds |

--- a/AUDIT_INSTRUCTIONS.md
+++ b/AUDIT_INSTRUCTIONS.md
@@ -301,6 +301,24 @@ Each repo's tests are self-contained. For cross-repo interactions, write tests i
 
 The existing test suite is extensive (165 files in nana-core-v6 alone). Review the invariant tests to understand what's already been proven — then try to break those invariants with configurations the tests don't cover.
 
+## Compiler and Version Info
+
+All contracts use **Solidity 0.8.26** targeting the **Cancun** EVM (transient storage opcodes available). Compiled with **via-IR** optimization at **200 runs**. All repos use Foundry for building and testing. Dependencies include OpenZeppelin 5.x, Solady, and Uniswap V4 core/periphery (where applicable). Overflow/underflow is checked by default (Solidity 0.8+); `unchecked` blocks are used sparingly and intentionally.
+
+## Top Trust Assumptions
+
+These are the most impactful trust assumptions in the protocol. A broken assumption = a finding:
+
+1. **Project owners are trusted by their token holders.** Owners can queue rulesets that change economics (weight, tax rate, reserved percent) with only an approval hook delay as protection. If the approval hook is `JBDeadline(0)` or absent, changes are instant.
+
+2. **Data hooks have absolute control over payment and cashout terms.** A malicious data hook can set `weight = type(uint256).max` (minting infinite tokens), `cashOutTaxRate = 0` (draining all surplus), or `totalSupply = 1` (concentrating all cashout value). Projects opt into hooks; users trust that the project's hook is safe.
+
+3. **Price feeds are immutable and trusted once set.** `JBPrices` does not allow replacing a feed. If a Chainlink feed goes stale beyond the threshold, operations using that currency pair revert (DoS but not fund loss). Project-specific feeds have no staleness requirement.
+
+4. **No reentrancy guards — CEI ordering is the only defense.** All hook callbacks (pay, cashout, split) can re-enter the protocol. The protocol relies on state being fully committed before external calls. Any deviation from this pattern is a critical finding.
+
+5. **Cross-chain bridge messages are trusted once verified by the underlying bridge.** Suckers verify merkle proofs against roots posted by the bridge (Optimism, Arbitrum, CCIP). If the bridge itself is compromised, sucker funds are at risk. This is a known, accepted dependency.
+
 ## Priority Order
 
 Audit in this order. Earlier items have higher blast radius:

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -14,6 +14,8 @@ See [nana-router-terminal-v6/CHANGE_LOG.md](./nana-router-terminal-v6/CHANGE_LOG
 
 The buyback hook was rewritten from Uniswap V3 to V4. All swap logic now goes through V4's `IPoolManager` singleton. The slippage algorithm changed from a 9-tier step function to a continuous sigmoid curve. TWAP queries use V4 oracle hooks instead of V3's `OracleLibrary`. The shared swap math lives in a new `JBSwapLib` library used by both the buyback hook and router terminal.
 
+**Sell-side cash out optimization:** The buyback hook now also implements `IJBCashOutHook` and optimizes sell-side cash outs. `beforeCashOutRecordedWith` compares the protocol's bonding curve reclaim value against selling reminted tokens into the Uniswap V4 pool. If the pool route is better, the hook executes the sell via `afterCashOutRecordedWith`. If the protocol cash out wins, the hook returns a noop specification with routing metadata so preview clients can still inspect the comparison.
+
 See [nana-buyback-hook-v6/CHANGE_LOG.md](./nana-buyback-hook-v6/CHANGE_LOG.md) for details.
 
 ### New: UniV4 LP Split Hook + UniV4 Router
@@ -60,8 +62,28 @@ Full details: [nana-core-v6/CHANGE_LOG.md](./nana-core-v6/CHANGE_LOG.md)
 - `IJBPayoutTerminal.sendPayoutsOf` return value changed to `amountPaidOut`
 - Several interfaces changed `memory` params to `calldata`
 
+**Migration examples:**
+
+```solidity
+// updateRulesetWeightCache — V5 vs V6
+// V5: rulesets.updateRulesetWeightCache(projectId)
+// V6: rulesets.updateRulesetWeightCache(projectId, rulesetId)
+//     rulesetId = the specific ruleset to cache from (use currentOf().id)
+
+// sendPayoutsOf — V5 vs V6
+// V5: uint256 netLeftoverPayoutAmount = terminal.sendPayoutsOf(projectId, token, amount, currency, minTokensPaidOut);
+// V6: uint256 amountPaidOut = terminal.sendPayoutsOf(projectId, token, amount, currency, minTokensPaidOut);
+//     Return value changed from leftover to total paid out.
+
+// deployWith721sFor — removed in V6
+// V5: revDeployer.deployWith721sFor(revnetId, config, terminals, suckers, tiered721Config)
+// V6: revDeployer.deployFor(revnetId, config, terminals, suckers, tiered721Config, allowedPosts)
+//     Both deployFor overloads now auto-deploy a 721 hook. Use the 6-arg version for configured tiers.
+```
+
 **New capabilities:**
-- `previewPayFrom` / `previewCashOutFrom` — `view` functions on `JBTerminalStore` that simulate the full payment or cash out on-chain, including data hook effects. Useful for UIs and integrations to preview exact outcomes before sending a transaction.
+- `previewPayFrom` / `previewCashOutFrom` — `view` functions on `JBTerminalStore` that simulate the full payment or cash out on-chain, including data hook effects. Terminal-level wrappers (`JBMultiTerminal.previewPayFor`, `JBMultiTerminal.previewCashOutFrom`) compose the store previews with mint token splitting. Useful for UIs and integrations to preview exact outcomes before sending a transaction.
+- Noop hook specifications — `JBPayHookSpecification` and `JBCashOutHookSpecification` gained a `bool noop` field. When `noop = true`, the terminal skips the hook callback but the spec remains available to preview clients. The store enforces `noop = true` + `amount != 0` reverts (`JBTerminalStore_NoopHookSpecHasAmount`). The buyback hook uses noop specs to return routing diagnostics (TWAP tick, liquidity, pool ID) when the protocol path wins.
 - `setTokenMetadataOf` — mutable ERC-20 and 721 name/symbol after deployment (new `SET_TOKEN_METADATA` permission)
 - `JBCashOuts.minCashOutCountFor` — inverse bonding curve (binary search for minimum tokens needed)
 - `IJBMigratable.afterReceiveMigrationFrom` — callback after migration

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Juicebox V6
 
-Programmable treasuries for Ethereum. Projects collect funds, issue tokens, cash out along bonding curves, govern economics through rulesets, and compose features through hooks — all onchain, all composable, across any EVM chain.
+Juicebox is an Ethereum protocol for programmable treasuries. [App](https://juicebox.money) | [Docs](https://docs.juicebox.money)
+
+Projects collect funds, issue tokens, cash out along bonding curves, govern economics through rulesets, and compose features through hooks — all onchain, all composable, across any EVM chain.
 
 This is the complete V6 smart contract ecosystem spanning core protocol, hooks, cross-chain bridging, deployers, and applications. Clone recursively to get everything:
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Hooks plug into the core at well-defined extension points. Data hooks override e
 | Repo | What it does |
 |------|-------------|
 | [nana-721-hook-v6](./nana-721-hook-v6) | Tiered NFTs — mint on payment, burn to cash out. Per-tier pricing, supply caps, reserve frequency, discount rates. |
-| [nana-buyback-hook-v6](./nana-buyback-hook-v6) | Data hook that compares minting vs buying from Uniswap V4, takes whichever gives more tokens. TWAP oracle with sigmoid slippage. |
+| [nana-buyback-hook-v6](./nana-buyback-hook-v6) | Data hook that routes both buy-side payments and sell-side cash outs through the better of the protocol path or a Uniswap V4 pool. TWAP oracle with sigmoid slippage. |
 | [univ4-lp-split-hook-v6](./univ4-lp-split-hook-v6) | Split hook that accumulates reserved tokens and deploys them into UniV4 concentrated liquidity positions bounded by issuance and cash-out rates. |
 | [univ4-router-v6](./univ4-router-v6) | Uniswap V4 hook with custom swap logic and oracle tracking for buyback integration. |
 
@@ -80,7 +80,7 @@ Hooks plug into the core at well-defined extension points. Data hooks override e
 
 | Repo | What it does |
 |------|-------------|
-| [deploy-all-v6](./deploy-all-v6) | Single Foundry script that deploys the entire ecosystem (~1,600 lines). Sphinx orchestration across 8 chains. |
+| [deploy-all-v6](./deploy-all-v6) | Single Foundry script that deploys the entire ecosystem (~2,200 lines). Sphinx orchestration across 8 chains. |
 
 ## Building
 

--- a/RISKS.md
+++ b/RISKS.md
@@ -1,6 +1,6 @@
 # Risks
 
-Trust assumptions, known risks, and security properties of Juicebox V6. For per-repo risk details, see each repo's `RISKS.md`. For audit findings, see [AUDIT.md](./AUDIT.md).
+Trust assumptions, known risks, and security properties of Juicebox V6. For per-repo risk details, see each repo's `RISKS.md`.
 
 ## Trust Model
 
@@ -34,6 +34,7 @@ Trust assumptions, known risks, and security properties of Juicebox V6. For per-
 | No reentrancy guard | Protocol relies on CEI ordering, not mutex | State updates before all external calls |
 | Weight cache requirement | Projects with >20k cycles need progressive cache updates | Anyone can call `updateRulesetWeightCache` |
 | Fee-on-fee compounding | Fees on hooks that themselves trigger fees | Each fee layer is bounded; no unbounded recursion |
+| Noop hook spec suppression | A data hook can return noop hook specifications, suppressing hook callbacks while its own weight/tax rate/supply overrides still take effect | By design — the `noop` flag controls only whether the pay/cashout hook callback executes. The data hook's parameter overrides (weight, tax rate, supply) are applied before hook callbacks and are unaffected by `noop`. |
 
 ## Operational Risks
 
@@ -125,7 +126,7 @@ The protocol uses no `ReentrancyGuard`. It relies on state ordering (CEI pattern
 | `REVLoans.borrowFrom` | Collateral locked BEFORE funds transferred | LOW |
 | `REVLoans.repayLoan` | Loan state cleared BEFORE collateral returned | LOW |
 
-**Key defense**: `JBTerminalStore_InadequateTerminalStoreBalance` revert prevents extracting more than available balance regardless of reentrancy.
+**Key defense**: `JBTerminalStore_InadequateTerminalStoreBalance` revert prevents direct over-extraction of terminal balance.
 
 **Gap**: Complex cross-function reentrancy (hook calling back into a *different* terminal function) is not explicitly prevented. The LP split hook has no reentrancy protection at all.
 

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -4,7 +4,7 @@ Fast-access reference for finding anything in the V6 ecosystem. Use this when yo
 
 ## Common Approaches
 
-**"How do payments work?"** — Start at `JBMultiTerminal._pay()` (L1393). It calls `JBTerminalStore.recordPaymentFrom()` for bookkeeping, then `JBController.mintTokensOf()` for token issuance, then executes any pay hooks. The data hook (if set) can override the weight before minting.
+**"How do payments work?"** — Start at `JBMultiTerminal._pay()` (L1432). It calls `JBTerminalStore.recordPaymentFrom()` for bookkeeping, then `JBController.mintTokensOf()` for token issuance, then executes any pay hooks. The data hook (if set) can override the weight before minting.
 
 **"How do I build a custom hook?"** — Implement `IJBPayHook` (called after payment) or `IJBCashOutHook` (called after cashout). For economics override, implement `IJBRulesetDataHook`. See `JB721TiersHook` for a pay+cashout hook example, `JBBuybackHook` for a data hook example. Hooks are set per-ruleset in the metadata.
 
@@ -20,35 +20,35 @@ Fast-access reference for finding anything in the V6 ecosystem. Use this when yo
 
 | Flow | Entry Point | Key Logic |
 |------|------------|-----------|
-| Payment | `JBMultiTerminal._pay()` L1393 | `JBTerminalStore.recordPaymentFrom()` L308 |
-| Cash out | `JBMultiTerminal._cashOutTokensOf()` L1018 | `JBTerminalStore.recordCashOutFor()` L167 |
-| Payout distribution | `JBMultiTerminal.sendPayoutsOf()` L699 | Splits loop → `executePayout()` |
-| Surplus calculation | `JBTerminalStore._tokenSurplusFrom()` L813 | Cross-terminal aggregation via JBSurplus |
+| Payment | `JBMultiTerminal._pay()` L1432 | `JBTerminalStore.recordPaymentFrom()` L318 |
+| Cash out | `JBMultiTerminal._cashOutTokensOf()` L1053 | `JBTerminalStore.recordCashOutFor()` L248 |
+| Payout distribution | `JBMultiTerminal.sendPayoutsOf()` L652 | Splits loop → `executePayout()` |
+| Surplus calculation | `JBTerminalStore._tokenSurplusFrom()` L1169 | Cross-terminal aggregation via JBSurplus |
 | Bonding curve | `JBCashOuts.cashOutFrom()` L20 | `base * [(MAX-tax) + tax*(count/supply)] / MAX` |
-| Token minting | `JBController.mintTokensOf()` L492 | Reserved accumulation in `pendingReservedTokenBalanceOf` |
-| Reserved distribution | `JBController._sendReservedTokensToSplitsOf()` L1078 | Mints then distributes to splits |
+| Token minting | `JBController.mintTokensOf()` L497 | Reserved accumulation in `pendingReservedTokenBalanceOf` |
+| Reserved distribution | `JBController._sendReservedTokensToSplitsOf()` L1109 | Mints then distributes to splits |
 | Ruleset queuing | `JBRulesets.queueFor()` L116 | Linked list via `basedOnId` |
-| Weight decay | `JBRulesets.deriveWeightFrom()` L610 | Cache required after 20k cycles |
-| Permission check | `JBPermissions.hasPermission()` L191 | 256-bit packed, ROOT=1 grants all |
-| Fee processing | `JBMultiTerminal._processFee()` L1479 | 2.5% to project #1, 28-day hold |
-| Held fee return | `JBMultiTerminal.processHeldFeesOf()` L631 | Sequential from `_nextHeldFeeIndexOf` |
+| Weight decay | `JBRulesets.deriveWeightFrom()` L613 | Cache required after 20k cycles |
+| Permission check | `JBPermissions.hasPermission()` L193 | 256-bit packed, ROOT=1 grants all |
+| Fee processing | `JBMultiTerminal._processFee()` L1508 | 2.5% to project #1, 28-day hold |
+| Held fee return | `JBMultiTerminal.processHeldFeesOf()` L584 | Sequential from `_nextHeldFeeIndexOf` |
 | Preview payment | `JBTerminalStore.previewPayFrom()` | Simulates payment (view). Returns token count + hook specs |
 | Preview cash out | `JBTerminalStore.previewCashOutFrom()` | Simulates cash out (view). Returns reclaim amount, tax rate, hook specs |
 | Data hook (pay) | `JBTerminalStore.recordPaymentFrom()` L308 | Hook overrides weight + specifies pay hooks |
 | Data hook (cashout) | `JBTerminalStore.recordCashOutFor()` L167 | Hook overrides tax rate, count, supply |
-| NFT tier mint | `JB721TiersHookStore.recordMint()` L1023 | Tier selection by price, supply cap check |
-| Buyback decision | `JBBuybackHook._getQuote()` L832 | TWAP vs spot, mint vs swap |
-| Loan creation | `REVLoans.borrowFrom()` L545 | Collateral lock, bonding curve valuation |
+| NFT tier mint | `JB721TiersHookStore.recordMint()` L1037 | Tier selection by price, supply cap check |
+| Buyback decision | `JBBuybackHook._getQuote()` L1035 | TWAP oracle query, mint vs swap |
+| Loan creation | `REVLoans.borrowFrom()` L551 | Collateral lock, bonding curve valuation |
 | Cross-chain prepare | `JBSucker.prepare()` | Cash out + insert into outbox merkle tree |
 | Cross-chain claim | `JBSucker.claim()` | Verify merkle proof + mint/transfer |
 | LP pool deploy | `JBUniswapV4LPSplitHook.deployPool()` | Concentrated liquidity from accumulated tokens |
-| Defifa game launch | `DefifaDeployer.launchGameWith()` L390 | Creates project + queues phase rulesets |
-| Defifa scorecard | `DefifaGovernor.submitScorecardFor()` L411 | Allocates `TOTAL_CASHOUT_WEIGHT` (1e18) across tiers |
-| Defifa attestation | `DefifaGovernor.attestToScorecardFrom()` L321 | Per-tier power, capped at 1e9 |
-| Defifa ratification | `DefifaGovernor.ratifyScorecardFrom()` L363 | Quorum = 50% of eligible attestation power |
+| Defifa game launch | `DefifaDeployer.launchGameWith()` L362 | Creates project + queues phase rulesets |
+| Defifa scorecard | `DefifaGovernor.submitScorecardFor()` L185 | Allocates `TOTAL_CASHOUT_WEIGHT` (1e18) across tiers |
+| Defifa attestation | `DefifaGovernor.attestToScorecardFrom()` L97 | Per-tier power, capped at 1e9 |
+| Defifa ratification | `DefifaGovernor.ratifyScorecardFrom()` L139 | Quorum = 50% of eligible attestation power |
 | Defifa cash-out weight | `DefifaHookLib.computeCashOutWeight()` L95 | `weight / tokens` — integer truncation |
-| Defifa game phase | `DefifaDeployer.currentGamePhaseOf()` L221 | COUNTDOWN → MINT → REFUND → SCORING → COMPLETE |
-| Full ecosystem deploy | `deploy-all-v6/script/Deploy.s.sol` (1572 lines) | 9-phase Sphinx deployment across 8 chains |
+| Defifa game phase | `DefifaDeployer.currentGamePhaseOf()` L219 | COUNTDOWN → MINT → REFUND → SCORING → COMPLETE |
+| Full ecosystem deploy | `deploy-all-v6/script/Deploy.s.sol` (2230 lines) | 9-phase Sphinx deployment across 8 chains |
 
 All paths in `nana-core-v6/src/` unless noted otherwise.
 
@@ -80,6 +80,7 @@ All paths in `nana-core-v6/src/` unless noted otherwise.
 | `CreditTransfersPaused` | JBController | Ruleset pauses credit transfers |
 | `RulesetsAlreadyLaunched` | JBController | Can't launch twice |
 | `WeightCacheRequired` | JBRulesets | >20k cycles without cache update |
+| `NoopHookSpecHasAmount` | JBTerminalStore | Noop hook spec has non-zero amount (noop specs are informational-only) |
 | `LeafAlreadyExecuted` | JBSucker | Cross-chain claim already processed |
 | `NothingToClaim` | DefifaHook | Cash out attempted during SCORING phase |
 
@@ -107,6 +108,7 @@ All paths in `nana-core-v6/src/` unless noted otherwise.
 19. **Don't queue multiple identical rulesets** — a ruleset with `duration` auto-cycles. Only queue multiple when config actually changes between periods.
 20. **Revnet loans beat cash-outs above ~39% `cashOutTaxRate`** — below ~39%, cash-out is more capital-efficient (CryptoEconLab finding)
 21. **`NATIVE_TOKEN` represents a different token on each chain.** `NATIVE_TOKEN` (`0x000000000000000000000000000000000000EEEe`) is the token received via `msg.value` — ETH on Ethereum/Base/Optimism/Arbitrum, CELO on Celo, etc. Its currency is `uint32(uint160(NATIVE_TOKEN))` = 61166. A `JBMatchingPriceFeed` (returns 1:1) is deployed for `ETH:NATIVE_TOKEN` on ETH-native chains so that `baseCurrency=ETH` resolves correctly to the native token. On non-ETH-native chains, a different price feed would be needed.
+22. **Noop hook specifications** are informational-only — `noop = true` + `amount != 0` reverts with `JBTerminalStore_NoopHookSpecHasAmount`. Data hooks (like the buyback hook) use noop specs to return routing diagnostics to preview clients without triggering a hook callback.
 
 ## Permission IDs
 
@@ -193,7 +195,7 @@ nana-buyback-hook-v6
   JBBuybackHook.sol              909   █████████
 
 deploy-all-v6
-  Deploy.s.sol             1,572   ████████████████
+  Deploy.s.sol             2,230   ██████████████████████
 ```
 
 ## Testing

--- a/USER_JOURNEYS.md
+++ b/USER_JOURNEYS.md
@@ -2,6 +2,17 @@
 
 How to use Juicebox V6. Three paths, one protocol.
 
+### Key Terms
+
+| Term | Meaning |
+|------|---------|
+| **Ruleset** | A time-bounded configuration that governs a project's economics — issuance weight, duration, tax rate, hooks, and access limits. Rulesets cycle automatically when their duration expires. |
+| **Surplus** | Funds held by a project's terminals beyond what's needed for configured payouts. Token holders can cash out against the surplus. |
+| **Bonding curve** | The math that determines how much a token holder receives when cashing out. Controlled by the cash out tax rate. |
+| **Cash out tax** | A rate (0–100%) that curves the bonding curve. 0% = proportional share. Higher = steeper penalty for partial cash outs. |
+| **Data hook** | A contract that overrides payment weight or cash out parameters before the terminal records the operation. Set per-ruleset. |
+| **Hook specification** | A struct returned by a data hook describing which pay/cashout hooks to call after settlement, and with how much. Can be marked `noop` to skip the callback. |
+
 ## Start a Project
 
 ### Path 1: Omnichain Project
@@ -94,7 +105,9 @@ JBMultiTerminal.pay(projectId, token, amount, beneficiary, minReturnedTokens, me
 
 The terminal records the payment, mints project tokens to the beneficiary (at the current ruleset's weight), and executes any pay hooks (NFT minting, buyback swaps). If the project uses a router terminal, you can pay with any token — it swaps to the project's accepted token automatically.
 
-**Preview**: Call `JBTerminalStore.previewPayFrom(terminal, payer, amount, projectId, beneficiary, metadata)` to simulate the full payment on-chain — including data hook effects on weight and hook specifications. This is a `view` function that does not modify state.
+The `metadata` parameter is a variable-length key-value payload encoded via `JBMetadataResolver`. Common uses: Permit2 approval data (gasless ERC-20 payments), buyback hook quotes (TWAP tick, pool selection), 721 tier IDs to mint, and custom data hook payloads. See [SKILLS.md](./SKILLS.md#libraries) for `JBMetadataResolver` encoding format.
+
+**Preview**: Call `JBMultiTerminal.previewPayFor(projectId, token, amount, beneficiary, metadata)` to simulate the full payment on-chain — including data hook effects on weight, reserved/beneficiary token split, and hook specifications. This is a `view` function that does not modify state. When a buyback hook is active, the returned hook specifications may include noop specs with routing diagnostics (TWAP tick, liquidity, pool ID) even when the protocol mint path wins — allowing UIs to show the comparison without a second call.
 
 ### Cash Out
 
@@ -108,7 +121,7 @@ The amount returned follows the bonding curve: `surplus * (count/supply) * [(1-t
 
 Always set `minTokensReclaimed` to protect against slippage.
 
-**Preview**: Call `JBTerminalStore.previewCashOutFrom(terminal, holder, projectId, cashOutCount, accountingContext, balanceAccountingContexts, beneficiaryIsFeeless, metadata)` to simulate the full cash out on-chain — including data hook effects on tax rate, supply, and hook specifications. This is a `view` function that does not modify state. For a simpler estimate without data hook effects, use `currentTotalReclaimableSurplusOf(projectId, cashOutCount, decimals, currency)`.
+**Preview**: Call `JBMultiTerminal.previewCashOutFrom(holder, projectId, cashOutCount, tokenToReclaim, beneficiary, metadata)` to simulate the full cash out on-chain — including data hook effects on tax rate, supply, and hook specifications. This is a `view` function that does not modify state. For a lower-level preview, use `JBTerminalStore.previewCashOutFrom(terminal, holder, projectId, cashOutCount, tokenToReclaim, beneficiaryIsFeeless, metadata)`. For a simpler estimate without data hook effects, use `currentTotalReclaimableSurplusOf(projectId, cashOutCount, decimals, currency)`.
 
 ### Borrow Against Tokens (revnets only)
 


### PR DESCRIPTION
## Summary
- Add Compiler/Version Info paragraph (Solidity 0.8.26, Cancun, via-IR, 200 runs)
- Add Top Trust Assumptions section (5 key assumptions that, if broken, are findings)

Brings the top-level audit instructions from A to A+.

🤖 Generated with [Claude Code](https://claude.com/claude-code)