### PR TITLE
Fix 9 factual errors in top-level RISKS.md

### DIFF
--- a/RISKS.md
+++ b/RISKS.md
@@ -21,17 +21,17 @@ These risks emerge from the composition of multiple repos, not from any single c
 
 - **Chain:** `REVDeployer.beforePayRecordedWith` (revnet-core) → `JBBuybackHook.beforePayRecordedWith` (nana-buyback-hook) → `JBUniswapV4Hook._beforeSwap` (univ4-router) → `JBMultiTerminal.pay` (nana-core)
 - **Risk:** The revnet deployer acts as a proxy data hook, delegating to the buyback hook, which queries the V4 router hook for TWAP comparison, which may route back through a JB terminal payment. This creates a 4-contract delegation chain where each layer transforms the payment context. A bug in any layer's weight/amount transformation propagates through the entire chain.
-- **Reentrancy path:** V4 router hook routes through `terminal.pay()` → triggers `REVDeployer.beforePayRecordedWith` again → detects recursion via `_routing` transient storage flag → reverts → caught by buyback hook try-catch → falls back to mint. This is tested and safe, but the 4-layer depth makes reasoning about state ordering difficult.
+- **Reentrancy path:** V4 router hook routes through `terminal.pay()` → triggers `REVDeployer.beforePayRecordedWith` again → detects recursion via `_routing` reentrancy flag (regular storage) → reverts → caught by buyback hook try-catch → falls back to mint. This is tested and safe, but the 4-layer depth makes reasoning about state ordering difficult.
 
 ### Sucker registry → omnichain deployer → revnet deployer → 0% cashout
 
 - **Chain:** `JBSuckerRegistry.isSuckerOf` (nana-suckers) → `JBOmnichainDeployer.beforeCashOutRecordedWith` (nana-omnichain-deployers) → `REVDeployer.beforeCashOutRecordedWith` (revnet-core)
-- **Risk:** Both the omnichain deployer and revnet deployer grant 0% cashout tax to suckers identified by the registry. A compromised sucker registry entry affects every project across both deployer types simultaneously. The registry has `MAP_SUCKER_TOKEN` wildcard permission (`projectId=0`) from both deployers, meaning a single registry compromise has ecosystem-wide blast radius.
-- **Defense depth:** Sucker deployment requires `DEPLOY_SUCKERS` permission + per-stage `extraMetadata` bit check. But once deployed and registered, the sucker has permanent 0% cashout access.
+- **Risk:** Both the omnichain deployer and revnet deployer grant 0% cashout tax to suckers identified by the registry. A compromised sucker registry entry affects every project across both deployer types simultaneously. The registry has `MAP_SUCKER_TOKEN` wildcard permission (`projectId=0`) from all three grantors (`JBOmnichainDeployer`, `CTDeployer`, and `REVDeployer`), meaning a single registry compromise has ecosystem-wide blast radius.
+- **Defense depth:** Sucker deployment requires `DEPLOY_SUCKERS` permission + `suckerDeployerIsAllowed` allowlist check. But once deployed and registered, the sucker has permanent 0% cashout access.
 
 ### Controller migration → terminal migration → held fee escape
 
-- **Chain:** `JBController.migrate` (nana-core) → `JBDirectory.setControllerOf` → `JBMultiTerminal.migrateBalanceOf` (nana-core)
+- **Chain:** Controller migration: `JBDirectory.setControllerOf` → `JBController.migrate`. Terminal migration: `JBMultiTerminal.migrateBalanceOf` (independent operation, not linked to controller migration).
 - **Risk:** Terminal migration moves balances but intentionally does NOT migrate held fees (they belong to project #1). A project owner could migrate to a new terminal to escape held fee obligations — the old terminal retains the held fees but the project's balance is in the new terminal. The held fees eventually unlock and are processed, but they draw from the old terminal's balance which may now be zero.
 - **Mitigation:** `processHeldFeesOf` returns fees to the project balance if the fee payment fails. But if the old terminal has zero balance, there's nothing to return. The fee is effectively forgiven.
 
@@ -41,7 +41,7 @@ Contracts that serve as singletons across the ecosystem create correlated failur
 
 | Singleton | Used By | Failure Mode |
 |-----------|---------|-------------|
-| `JBBuybackHook` | All revnets from same deployer | Swap routing fails → all payments fall back to mint (economic inefficiency, not fund loss) |
+| `JBBuybackHookRegistry` | All revnets from same deployer | Swap routing fails → all payments fall back to mint (economic inefficiency, not fund loss) |
 | `JBUniswapV4Hook` | All V4 pools referencing it as hook | Oracle stops recording → TWAP stales → routing degradation across all pools |
 | `JBSuckerRegistry` | All omnichain deployers + revnet deployers | False sucker registration → 0% cashout tax drain across all projects |
 | `JBPrices` (default feeds) | All projects using cross-currency | Feed goes stale → all cross-currency operations halt |
@@ -58,15 +58,15 @@ These contracts hold wildcard permissions that apply to ALL projects:
 | Contract | Permission | Granted By | Risk |
 |----------|-----------|-----------|------|
 | `REVLoans` | `USE_ALLOWANCE` | `REVDeployer` constructor | Can draw surplus from ANY revnet's treasury |
-| `JBSuckerRegistry` | `MAP_SUCKER_TOKEN` | `JBOmnichainDeployer` + `CTDeployer` constructors | Can map tokens for ANY project |
-| `CTPublisher` | `ADJUST_721_TIERS` | `CTProjectOwner.onERC721Received` | Can adjust tiers for ANY project transferred to CTProjectOwner |
-| `OMNICHAIN_RULESET_OPERATOR` | `LAUNCH_RULESETS` + `QUEUE_RULESETS` + `SET_TERMINALS` | `JBController` constructor | Can queue rulesets for ANY project |
+| `JBSuckerRegistry` | `MAP_SUCKER_TOKEN` | `JBOmnichainDeployer` + `CTDeployer` + `REVDeployer` constructors | Can map tokens for ANY project |
+| `CTPublisher` | `ADJUST_721_TIERS` | `CTDeployer` constructor (wildcard `projectId: 0`) | Can adjust tiers for ANY project |
+| `OMNICHAIN_RULESET_OPERATOR` | `LAUNCH_RULESETS` + `QUEUE_RULESETS` + `SET_TERMINALS` | Hardcoded `alsoGrantAccessIf` bypass in `JBController` (not a `JBPermissions` wildcard grant) | Can queue rulesets for ANY project |
 
 A vulnerability in any of these contracts has ecosystem-wide blast radius. Each should be audited at the highest scrutiny level.
 
 ### ROOT permission cascade
 
-`ROOT` (permission ID 1) grants ALL permissions, including future ones. If ROOT is granted to a contract that is later found to have a vulnerability, the attacker inherits every permission in the system. ROOT cannot be set for wildcard `projectId=0` (enforced by `setPermissionsFor`), limiting blast radius to individual projects. But a ROOT holder on project X cannot escalate to ROOT on project Y through any known path.
+`ROOT` (permission ID 1) grants ALL permissions, including future ones. If ROOT is granted to a contract that is later found to have a vulnerability, the attacker inherits every permission in the system. ROOT cannot be set for wildcard `projectId=0` by operators (non-account callers), enforced by `setPermissionsFor` — but the account itself CAN set ROOT for wildcard `projectId=0`. This limits operator blast radius to individual projects. But a ROOT holder on project X cannot escalate to ROOT on project Y through any known path.
 
 ## 4. Cross-Chain Consistency Requirements
 


### PR DESCRIPTION
## Summary

Fixes 9 factual errors in the top-level ecosystem risk document (`RISKS.md`):

1. **Section 1.2**: `_routing` is a regular `bool private` storage variable, not transient storage
2. **Section 1.3**: `MAP_SUCKER_TOKEN` is granted by all three deployers (`JBOmnichainDeployer`, `CTDeployer`, `REVDeployer`), not just two
3. **Section 1.3**: Sucker deployment defense is `DEPLOY_SUCKERS` permission + `suckerDeployerIsAllowed` allowlist check, not a nonexistent `extraMetadata` bit check
4. **Section 1.4**: Controller migration (`JBDirectory.setControllerOf` -> `JBController.migrate`) and terminal migration (`migrateBalanceOf`) are independent operations, not a single call chain
5. **Section 2**: The singleton used by `REVDeployer` is `JBBuybackHookRegistry`, not individual `JBBuybackHook` instances
6. **Section 3.1**: Added `REVDeployer` as a grantor for `MAP_SUCKER_TOKEN` wildcard in the permission table
7. **Section 3.1**: `CTPublisher` / `ADJUST_721_TIERS` is granted by `CTDeployer` constructor (wildcard `projectId: 0`), not `CTProjectOwner.onERC721Received`
8. **Section 3.1**: `OMNICHAIN_RULESET_OPERATOR` is a hardcoded `alsoGrantAccessIf` bypass in `JBController`, not a `JBPermissions` wildcard grant
9. **Section 3.2**: ROOT wildcard restriction (`projectId=0`) only applies to operators (non-account callers); the account itself CAN set ROOT for wildcard projectId

## Test plan

- [ ] Verify each fix against the corresponding source code
- [ ] Confirm no stale historical references remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)