### PR TITLE
feat: add REVHiddenTokens and update ecosystem docs

### DIFF
--- a/ADMINISTRATION.md
+++ b/ADMINISTRATION.md
@@ -40,7 +40,7 @@ For contract-level admin documentation, see each subrepo's ADMINISTRATION.md:
 | nana-core-v6 | Protocol core: permissions, projects, directory, rulesets, terminals, tokens, prices, splits, fund access limits | [Link](nana-core-v6/ADMINISTRATION.md) |
 | nana-721-hook-v6 | NFT tiers, minting, metadata, discount percents | [Link](nana-721-hook-v6/ADMINISTRATION.md) |
 | nana-suckers-v6 | Cross-chain bridging, token mapping, deprecation, emergency hatch | [Link](nana-suckers-v6/ADMINISTRATION.md) |
-| revnet-core-v6 | Autonomous revnets, split operators, loans | [Link](revnet-core-v6/ADMINISTRATION.md) |
+| revnet-core-v6 | Autonomous revnets, split operators, loans, hidden tokens | [Link](revnet-core-v6/ADMINISTRATION.md) |
 | nana-buyback-hook-v6 | Buyback hook registry, pool configuration, TWAP | [Link](nana-buyback-hook-v6/ADMINISTRATION.md) |
 | nana-omnichain-deployers-v6 | Omnichain project deployment, data hook proxy | [Link](nana-omnichain-deployers-v6/ADMINISTRATION.md) |
 | nana-router-terminal-v6 | Router terminal registry, swap routing | [Link](nana-router-terminal-v6/ADMINISTRATION.md) |
@@ -52,7 +52,7 @@ For contract-level admin documentation, see each subrepo's ADMINISTRATION.md:
 | croptop-core-v6 | Croptop publishing, posting criteria | [Link](croptop-core-v6/ADMINISTRATION.md) |
 | deploy-all-v6 | Canonical deployment script | [Link](deploy-all-v6/ADMINISTRATION.md) |
 | banny-retail-v6 | Banny NFT metadata, outfit custodial model | [Link](banny-retail-v6/ADMINISTRATION.md) |
-| defifa-collection-deployer-v6 | Defifa game lifecycle, scorecard governance | [Link](defifa-collection-deployer-v6/ADMINISTRATION.md) |
+| defifa | Defifa game lifecycle, scorecard governance | [Link](defifa/ADMINISTRATION.md) |
 | univ4-lp-split-hook-v6 | LP split hook, pool deployment, fee routing | [Link](univ4-lp-split-hook-v6/ADMINISTRATION.md) |
 | univ4-router-v6 | V4 oracle hook (no admin surface) | [Link](univ4-router-v6/ADMINISTRATION.md) |
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -32,7 +32,7 @@ Application / product repos
   -> revnet-core-v6
   -> croptop-core-v6
   -> banny-retail-v6
-  -> defifa-collection-deployer-v6
+  -> defifa
   -> nana-fee-project-deployer-v6
 ```
 
@@ -126,10 +126,10 @@ Cross-chain support is deliberately implemented outside the core so the core rem
 | `nana-omnichain-deployers-v6` | Project launcher that composes 721 hooks, custom hooks, and suckers |
 | `univ4-router-v6` | Uniswap V4 hook plus TWAP oracle used by other repos |
 | `univ4-lp-split-hook-v6` | Reserved-token liquidity automation |
-| `revnet-core-v6` | Autonomous, ownerless project pattern with stage-based economics and loans |
+| `revnet-core-v6` | Autonomous, ownerless project pattern with stage-based economics, loans, and temporary token hiding |
 | `croptop-core-v6` | Permissioned NFT publishing product |
 | `banny-retail-v6` | On-chain composable avatar metadata system |
-| `defifa-collection-deployer-v6` | Prediction-game product built on tiered NFTs and governance |
+| `defifa` | Prediction-game product built on tiered NFTs and governance |
 | `nana-fee-project-deployer-v6` | Deployment of the protocol's fee beneficiary project |
 | `deploy-all-v6` | Canonical deployment orchestration for the entire stack |
 | `nana-privacy-v6` | Optional privacy components layered on top of existing payment flows |

--- a/AUDIT_INSTRUCTIONS.md
+++ b/AUDIT_INSTRUCTIONS.md
@@ -47,7 +47,7 @@ Primary runtime and deployment scope:
 - `univ4-router-v6`
 - `univ4-lp-split-hook-v6`
 - `croptop-core-v6`
-- `defifa-collection-deployer-v6`
+- `defifa`
 - `banny-retail-v6`
 - `nana-ownable-v6`
 - `nana-address-registry-v6`
@@ -77,7 +77,7 @@ Everything else composes around those primitives:
 - swap-vs-mint routing: `nana-buyback-hook-v6` and `univ4-router-v6`
 - multi-asset routing into accepted project tokens: `nana-router-terminal-v6`
 - cross-chain project token movement: `nana-suckers-v6`
-- launchers and protocol compositions: `nana-omnichain-deployers-v6`, `revnet-core-v6`, `croptop-core-v6`, `defifa-collection-deployer-v6`
+- launchers and protocol compositions: `nana-omnichain-deployers-v6`, `revnet-core-v6`, `croptop-core-v6`, `defifa`
 - application-level surfaces: `banny-retail-v6`, `nana-privacy-v6`
 - deployment orchestration: `deploy-all-v6`
 
@@ -101,7 +101,7 @@ Data hooks may modify accounting inputs only within the intended model. Hook spe
 Protocol fees and repo-specific fees must either be paid, held, or explicitly redirected by documented fallback logic. They must not silently disappear.
 
 6. Token accounting consistency
-Mint, burn, reserve, bridge, and reclaim paths must preserve intended supply and price relationships across ERC-20 credits, ERC-721 tiers, and bridged representations.
+Mint, burn, reserve, bridge, and reclaim paths must preserve intended supply and price relationships across ERC-20 credits, ERC-721 tiers, and bridged representations. Hidden token mechanics (temporarily burning and re-minting via `REVHiddenTokens`) must not enable supply manipulation or unexpected cash-out value changes beyond the intended effect of reducing totalSupply.
 
 7. Cross-chain conservation
 Prepare, send-root, receive-root, and claim paths must not enable replay, double claim, stranded balance creation, or source/destination divergence beyond documented emergency-hatch behavior.
@@ -171,7 +171,7 @@ Terminal solvency, cash-out math, payout and allowance enforcement, fee processi
 `nana-suckers-v6` and any deployer or owner helper that grants sucker privileges or fee exemptions.
 
 4. Autonomous compositions
-`revnet-core-v6`, `croptop-core-v6`, and `defifa-collection-deployer-v6`, where project-specific economics are built out of many shared primitives.
+`revnet-core-v6`, `croptop-core-v6`, and `defifa`, where project-specific economics are built out of many shared primitives.
 
 5. Deployment correctness
 `deploy-all-v6` and per-repo `script/` entries. Wrong wiring, wrong singleton addresses, missing ownership transfers, and missing registry writes are production-critical findings.

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -14,8 +14,8 @@
 | Buyback routing, TWAP quoting, or mint-vs-swap behavior | [`nana-buyback-hook-v6/SKILLS.md`](./nana-buyback-hook-v6/SKILLS.md) |
 | Router-terminal execution or route registry behavior | [`nana-router-terminal-v6/SKILLS.md`](./nana-router-terminal-v6/SKILLS.md) |
 | Cross-chain sucker bridging or token mapping behavior | [`nana-suckers-v6/SKILLS.md`](./nana-suckers-v6/SKILLS.md) |
-| Revnet deployer, owner, or loan logic | [`revnet-core-v6/SKILLS.md`](./revnet-core-v6/SKILLS.md) |
-| Croptop, Defifa, or Banny application-layer behavior | [`croptop-core-v6/SKILLS.md`](./croptop-core-v6/SKILLS.md), [`defifa-collection-deployer-v6/SKILLS.md`](./defifa-collection-deployer-v6/SKILLS.md), [`banny-retail-v6/SKILLS.md`](./banny-retail-v6/SKILLS.md) |
+| Revnet deployer, owner, loan, or hidden token logic | [`revnet-core-v6/SKILLS.md`](./revnet-core-v6/SKILLS.md) |
+| Croptop, Defifa, or Banny application-layer behavior | [`croptop-core-v6/SKILLS.md`](./croptop-core-v6/SKILLS.md), [`defifa/SKILLS.md`](./defifa/SKILLS.md), [`banny-retail-v6/SKILLS.md`](./banny-retail-v6/SKILLS.md) |
 | Utility repos like address registry, permission IDs, ownership helpers, or privacy | [`nana-address-registry-v6/SKILLS.md`](./nana-address-registry-v6/SKILLS.md), [`nana-permission-ids-v6/SKILLS.md`](./nana-permission-ids-v6/SKILLS.md), [`nana-ownable-v6/SKILLS.md`](./nana-ownable-v6/SKILLS.md), [`nana-privacy-v6/SKILLS.md`](./nana-privacy-v6/SKILLS.md) |
 | Uniswap V4 hook repos | [`univ4-lp-split-hook-v6/SKILLS.md`](./univ4-lp-split-hook-v6/SKILLS.md), [`univ4-router-v6/SKILLS.md`](./univ4-router-v6/SKILLS.md) |
 | Ecosystem deployment orchestration | [`deploy-all-v6/SKILLS.md`](./deploy-all-v6/SKILLS.md), [`nana-fee-project-deployer-v6/SKILLS.md`](./nana-fee-project-deployer-v6/SKILLS.md), [`nana-omnichain-deployers-v6/SKILLS.md`](./nana-omnichain-deployers-v6/SKILLS.md) |
@@ -29,9 +29,9 @@
 | `nana-buyback-hook-v6` | Buyback data hooks and swap quoting |
 | `nana-router-terminal-v6` | Router terminal and route registry |
 | `nana-suckers-v6` | Cross-chain suckers and deployers |
-| `revnet-core-v6` | Revnet deployer, owner, and loans |
+| `revnet-core-v6` | Revnet deployer, owner, loans, and hidden tokens |
 | `croptop-core-v6` | Croptop publishing and project deployer |
-| `defifa-collection-deployer-v6` | Defifa game deployer, hook, governor, resolver |
+| `defifa` | Defifa game deployer, hook, governor, resolver |
 | `banny-retail-v6` | Banny token URI resolver and outfit rendering |
 | `nana-omnichain-deployers-v6` | Omnichain deployment wrapper |
 | `nana-address-registry-v6` | Address registry for deployed contracts |

--- a/USER_JOURNEYS.md
+++ b/USER_JOURNEYS.md
@@ -49,10 +49,24 @@ This file answers one question: "I want to do something in Juicebox V6. Where do
 1. Define stage parameters, accepted terminals, optional NFT tiers, optional suckers, and the split operator.
 2. Deploy through `REVDeployer`.
 3. Participants buy in, receive revnet tokens, and move through the staged issuance schedule.
-4. Holders can cash out, bridge, or borrow against tokens through the configured revnet surfaces.
+4. Holders can cash out, bridge, borrow against, or temporarily hide tokens through the configured revnet surfaces.
 5. Post-launch changes remain limited to the bounded surfaces the revnet design leaves adjustable.
 
 **Tradeoff:** less governance flexibility, more credible economic immutability.
+
+## Journey 3a: Hide Or Reveal Revnet Tokens Temporarily
+
+**Use when:** token holders want to exclude their tokens from supply temporarily to benefit remaining holders' cash-out value.
+
+**Start here:** [revnet-core-v6](./revnet-core-v6/USER_JOURNEYS.md)
+
+**Flow**
+1. Grant `BURN_TOKENS` permission to the `REVHiddenTokens` contract.
+2. Call `REVHiddenTokens.hideTokensOf(revnetId, tokenCount)` to burn tokens and track them.
+3. Hidden tokens are excluded from `totalSupply`, increasing cash-out value for remaining holders.
+4. At any time, the original holder calls `REVHiddenTokens.revealTokensOf(revnetId, tokenCount, beneficiary)` to re-mint tokens without reserved percent.
+
+**Tradeoff:** tokens must be revealed before they can be used as loan collateral (explicit two-step process).
 
 ## Journey 4: Sell NFTs Or Content Alongside Treasury Participation
 
@@ -62,7 +76,7 @@ This file answers one question: "I want to do something in Juicebox V6. Where do
 - [nana-721-hook-v6](./nana-721-hook-v6/USER_JOURNEYS.md): fixed tiered NFT rewards, memberships, editions, raffles, claims.
 - [croptop-core-v6](./croptop-core-v6/USER_JOURNEYS.md): permissioned publishing, where allowed posters create new NFT tiers on an existing project.
 - [banny-retail-v6](./banny-retail-v6/USER_JOURNEYS.md): composable on-chain avatars and accessories.
-- [defifa-collection-deployer-v6](./defifa-collection-deployer-v6/USER_JOURNEYS.md): game-like collections where scorecards decide payout weights.
+- [defifa](./defifa/USER_JOURNEYS.md): game-like collections where scorecards decide payout weights.
 
 **Shared pattern**
 1. Configure or deploy the project and NFT surface.


### PR DESCRIPTION
## Summary
- Updates `revnet-core-v6` submodule to include the new standalone `REVHiddenTokens` contract (see https://github.com/rev-net/revnet-core-v6/pull/117)
- Updates ecosystem documentation: USER_JOURNEYS, ADMINISTRATION, AUDIT_INSTRUCTIONS, ARCHITECTURE, SKILLS

## Test plan
- [x] All 294 tests pass in revnet-core-v6
- [x] Documentation is consistent across all .md files

🤖 Generated with [Claude Code](https://claude.com/claude-code)