### PR TITLE
chore: add nana-project-payer-v6 as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -58,3 +58,6 @@
 [submodule "nana-project-handles-v6"]
 	path = nana-project-handles-v6
 	url = https://github.com/Bananapus/nana-project-handles-v6
+[submodule "nana-project-payer-v6"]
+	path = nana-project-payer-v6
+	url = https://github.com/Bananapus/nana-project-payer-v6


### PR DESCRIPTION
## Summary
- Adds `nana-project-payer-v6` as a git submodule pointing to `https://github.com/Bananapus/nana-project-payer-v6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)