### PR TITLE
docs: remove hidden tokens references

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -199,7 +199,7 @@ If a bug crosses one of these seams, assume the blast radius may be larger than 
 | `nana-distributor-v6` | Round-based reward distribution for 721 or `IVotes` staking bases |
 | `univ4-router-v6` | Uniswap V4 hook plus TWAP oracle surface for routing decisions |
 | `univ4-lp-split-hook-v6` | Reserved-token liquidity automation and LP fee routing |
-| `revnet-core-v6` | Ownerless staged project pattern with loans, hidden tokens, and hook composition |
+| `revnet-core-v6` | Ownerless staged project pattern with loans and hook composition |
 | `croptop-core-v6` | Permissioned NFT publishing product |
 | `banny-retail-v6` | Composable avatar rendering and attachment-custody system |
 | `defifa` | Prediction-game product with phased rulesets, scorecard governance, and game-piece cash-out logic |

--- a/AUDIT_INSTRUCTIONS.md
+++ b/AUDIT_INSTRUCTIONS.md
@@ -52,7 +52,7 @@ Ask the user three things. Present the options clearly so they can choose what t
 | 2 | NFT hooks | `nana-721-hook-v6`, `croptop-core-v6`, `banny-retail-v6` | Tier manipulation, credit vs cash interactions, metadata handling |
 | 3 | Routing & swaps | `nana-buyback-hook-v6`, `univ4-router-v6`, `univ4-lp-split-hook-v6`, `nana-router-terminal-v6` | Swap-vs-mint routing under adversarial liquidity, LP positioning, price coherence |
 | 4 | Cross-chain | `nana-suckers-v6`, `nana-omnichain-deployers-v6` | Bridge replay, double-claim, configuration drift, peer authentication |
-| 5 | Revnets | `revnet-core-v6` | Loan math, stage transitions, hidden tokens, cross-chain surplus |
+| 5 | Revnets | `revnet-core-v6` | Loan math, stage transitions, cross-chain surplus |
 | 6 | Games & apps | `defifa`, `croptop-core-v6`, `banny-retail-v6` | Game lifecycle, scoring, NFT minting rules |
 | 7 | Deployment | `deploy-all-v6`, `nana-fee-project-deployer-v6` | Privilege retention, ownership convergence, wiring correctness |
 

--- a/AUDIT_REPORT.md
+++ b/AUDIT_REPORT.md
@@ -33,9 +33,9 @@ Correlated edge cases and PoCs were checked against current code, current tests,
 Bottom line under the current threat model:
 
 - All twenty-two immediate `deploy-all-v6` one-shot blockers are now FIXED. Two ecosystem blockers (S, AH) remain deferred for swap-enabled CCIP suckers in a future rollout. See "Current Open Edge Case A" through "Current Open Edge Case AS" below.
-- Eight items (D, E, AF, AA, AD, 74, 66, 69) have been closed as ACCEPTED — all are explicitly documented and accepted in their respective RISKS.md files.
+- Eleven items (D, E, AF, AA, AD, 74, 66, 69, AV, AW, AY) have been closed as ACCEPTED — all are explicitly documented and accepted in their respective RISKS.md files.
 - Two items (Z, AQ) have been RESOLVED — Z via per-project feeless system (nana-core-v6 v0.0.44), AQ via `scopeCashOutsToLocalBalances` flag (revnet-core-v6 v0.0.45, omnichain-deployers-v6 v0.0.39).
-- Thirty-two items are now FIXED: AL, AM, AN, AO, AP, AE, R, U, AR, Q (previously fixed), plus A, AC, B, C, F, G, H, I, J, K, L, M, N, O, P, T, V, W, X, Y, AI, AJ, AK (deploy-all-v6 deploy/resume identity gates, verifier extensions, package bumps, and runbook rewrite).
+- Thirty-seven items are now FIXED: AL, AM, AN, AO, AP, AE, R, U, AR, Q (previously fixed), plus A, AC, B, C, F, G, H, I, J, K, L, M, N, O, P, T, V, W, X, Y, AI, AJ, AK (deploy-all-v6 deploy/resume identity gates, verifier extensions, package bumps, and runbook rewrite), plus AS, AT, AU, AX, AZ (regression audit fixes).
 - Two items (S, AH) are deferred — swap-enabled CCIP suckers and native routes are not in the initial rollout.
 - Two items (JD-1, JD-2) are out of EVM scope (frontend/jb-directory).
 - One item (58) has been accepted/deferred by admin.
@@ -92,6 +92,14 @@ Immediate `deploy-all-v6` blockers:
 | AP | ~~`CTDeployer` never revoking deployer-scoped hook permissions when a project NFT is transferred so former owners retain tier/metadata control.~~ | FIXED. Permissions revoked in `claimCollectionOwnershipOf` (croptop-core-v6 PR #125). |
 | AQ | ~~`REVOwner.beforeCashOutRecordedWith` unconditionally adds `remoteSurplusOf` and `remoteTotalSupplyOf` to cash-out calculations regardless of `useTotalSurplus` flag.~~ | RESOLVED. `scopeCashOutsToLocalBalances` flag gates remote surplus/supply addition in REVOwner and REVLoans (revnet-core-v6 PR #144, v0.0.45; omnichain-deployers-v6 PR #102). |
 | AR | ~~`JBUniswapV4LPSplitHook._createAndInitializePool` accepts an existing pool's attacker-chosen `sqrtPriceX96` without bounds validation, enabling DoS or price manipulation at pool initialization.~~ | FIXED. Bounds validation added (univ4-lp-split-hook-v6 PR #120, v0.0.32). |
+| AS | ~~`JBOmnichainDeployer.peerChainAdjustedAccountsOf` masks cross-chain adjusted supply/surplus/balance from `REVOwner` because the deployer's override only calls the store, not the hook.~~ | FIXED. Override now forwards to the hook's `peerChainAdjustedAccountsOf` (nana-omnichain-deployers-v6 PR #104, v0.0.41). |
+| AT | ~~`DefifaHook._currentPhase` uses `tokenTotalSupply()` instead of `totalMintCost` for `minParticipation` threshold, so `addToBalanceOf` inflates participation count.~~ | FIXED. Now uses `totalMintCost` (defifa PR #106, v0.0.32). |
+| AU | ~~`JBDistributor._vestTokenIds` pushes zero-amount vesting entries that pin `latestVestedIndexOf`, permanently blocking token claim advancement.~~ | FIXED. Zero-amount entries skipped (nana-distributor-v6 PR #21, v0.0.13). |
+| AV | `JBOwnable` NFT round-trip (transfer away and back) reactivates ownership. | ACCEPTED. By design; documented in `nana-ownable-v6/RISKS.md` (PR #74). |
+| AW | Defifa commitment payout failures are finalized as fulfilled when the try-catch swallows the revert. | ACCEPTED. By design; documented in `defifa/RISKS.md` section 8.7. |
+| AX | ~~`DefifaHook.mintReservesFor` mints from the store's naive `numberOfPendingReservesFor` count, which ignores refund burns, inflating `totalMintCost` with ghost reserves.~~ | FIXED. Count now capped by `adjustedPendingReservesFor(tierId)` (defifa PR #107, v0.0.33). |
+| AY | `CTPublisher` allowlist bypass via EIP-7702 delegated EOAs. | ACCEPTED. Documented in `croptop-core-v6/RISKS.md` section 7.5 (PR #127). |
+| AZ | ~~`Resume.s.sol._resumeBuybackHook` unconditionally calls `setHookFor`, reverting on re-runs when the hook is already pinned.~~ | FIXED. Idempotent check added (deploy-all-v6 PR #84, v0.0.19). |
 
 Future / expanded rollout blockers:
 
@@ -181,18 +189,18 @@ Suggested owner/workstream routing:
 
 | Workstream | Edge Case IDs | Primary repos/artifacts to assign |
 | --- | --- | --- |
-| Deploy execution and runbook | B, V, W, ~~AL~~, A, AB, AC, H, X | AL: FIXED (deploy-all-v6 PR #103). `deploy-all-v6`, Sphinx execution path, `DEPLOY.md`, canonical project phase scripts. |
+| Deploy execution and runbook | B, V, W, ~~AL~~, A, AB, AC, H, X, ~~AZ~~ | AL: FIXED (deploy-all-v6 PR #103). AZ: FIXED. Idempotent setHookFor (deploy-all-v6 PR #84, v0.0.19). `deploy-all-v6`, Sphinx execution path, `DEPLOY.md`, canonical project phase scripts. |
 | Deployment verifier and manifest exactness | C, F, G, I, J, K, L, M, N, O, P, T, Y, AI, AJ, AK | `deploy-all-v6/script/Verify.s.sol`, deploy manifests/env, per-chain address manifests, ownership/permission reports. |
 | Core terminal and router economics | ~~Z~~ | RESOLVED. Per-project feeless system (nana-core-v6 v0.0.44). (AA and AF closed as ACCEPTED.) |
-| Cross-chain and sucker protocol fixes | ~~AM~~, ~~AQ~~ | AM: FIXED. Conversion formula inverted (nana-suckers-v6 PR #118, v0.0.37). AQ: RESOLVED via `scopeCashOutsToLocalBalances` (revnet-core-v6 v0.0.45, omnichain-deployers-v6 v0.0.39). |
+| Cross-chain and sucker protocol fixes | ~~AM~~, ~~AQ~~, ~~AS~~ | AM: FIXED. Conversion formula inverted (nana-suckers-v6 PR #118, v0.0.37). AQ: RESOLVED via `scopeCashOutsToLocalBalances` (revnet-core-v6 v0.0.45, omnichain-deployers-v6 v0.0.39). AS: FIXED. Deployer forwards to hook (nana-omnichain-deployers-v6 PR #104, v0.0.41). |
 | Revnet product economics | ~~AN~~, ~~D, E~~ | AN: FIXED. Now uses terminal token decimals (revnet-core-v6 PR #143). D, E: ACCEPTED per `revnet-core-v6/RISKS.md` §4 and §8. |
-| Product/periphery runtime safety | ~~AD~~, ~~AE~~, AG, ~~AO~~, ~~AP~~, ~~AR~~, ~~Q~~, ~~R~~, ~~U~~ | AE: FIXED (nana-distributor-v6 PR #18). AO, AP: FIXED (croptop-core-v6 PR #125). R: FIXED (nana-project-handles-v6 PRs #11, #14). U: FIXED (604,800s round duration). AR: FIXED (univ4-lp-split-hook-v6 PR #120, v0.0.32). AD: ACCEPTED (`defifa/RISKS.md` §1, §8.5). Q: FIXED (nana-721-hook-v6 PR #129, v0.0.47). All closed. |
+| Product/periphery runtime safety | ~~AD~~, ~~AE~~, AG, ~~AO~~, ~~AP~~, ~~AR~~, ~~Q~~, ~~R~~, ~~U~~, ~~AT~~, ~~AU~~, ~~AX~~ | AE: FIXED (nana-distributor-v6 PR #18). AO, AP: FIXED (croptop-core-v6 PR #125). R: FIXED (nana-project-handles-v6 PRs #11, #14). U: FIXED (604,800s round duration). AR: FIXED (univ4-lp-split-hook-v6 PR #120, v0.0.32). AD: ACCEPTED (`defifa/RISKS.md` §1, §8.5). Q: FIXED (nana-721-hook-v6 PR #129, v0.0.47). AT: FIXED (defifa PR #106, v0.0.32). AU: FIXED (nana-distributor-v6 PR #21, v0.0.13). AX: FIXED (defifa PR #107, v0.0.33). AV, AW, AY: ACCEPTED per RISKS.md. All closed. |
 | Cross-chain future rollout | S, AH | DEFERRED. Not in initial rollout. `nana-suckers-v6`, swap-enabled CCIP manifest policy. |
 | Static interface publication | JD-1, JD-2 | OUT OF SCOPE (frontend). `jb-directory`, ABI/address manifest generation, token/chain UX, publication build checks. |
 
 ## Implementation Handoff TLDR
 
-Current status: `NOT READY`. `AUDIT_REPORT.md` contains 23 confirmed open immediate `deploy-all-v6` blockers, 2 deferred future/expanded swap-enabled sucker blockers (S, AH), 9 items closed as ACCEPTED per RISKS.md (D, E, AA, AF, AD, Q, 66, 69, 74), 2 items RESOLVED (Z via per-project feeless, AQ via `scopeCashOutsToLocalBalances`), 9 items FIXED (AL, AM, AN, AO, AP, AE, R, U, AR), and 1 accepted/deferred (58). Separate `jb-directory` publication edge cases JD-1 and JD-2 are not EVM deployment blockers (frontend scope), but should gate publication of the static interface.
+Current status: `NOT READY`. `AUDIT_REPORT.md` contains 23 confirmed open immediate `deploy-all-v6` blockers, 2 deferred future/expanded swap-enabled sucker blockers (S, AH), 12 items closed as ACCEPTED per RISKS.md (D, E, AA, AF, AD, Q, 66, 69, 74, AV, AW, AY), 2 items RESOLVED (Z via per-project feeless, AQ via `scopeCashOutsToLocalBalances`), 14 items FIXED (AL, AM, AN, AO, AP, AE, R, U, AR, AS, AT, AU, AX, AZ), and 1 accepted/deferred (58). Separate `jb-directory` publication edge cases JD-1 and JD-2 are not EVM deployment blockers (frontend scope), but should gate publication of the static interface.
 
 Start implementation with deploy execution and runbook blockers: B, V, W, A, AB, AC, H, and X. (AL is now FIXED.) These determine whether the audited source graph is used, whether Sphinx/Safe execution preserves deterministic CREATE2 semantics, whether resume can actually be run, whether canonical projects `1-4` are recoverable/idempotent, whether Defifa verification can pass a correct deploy, and whether canonical buyback hooks/pools are present.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,7 @@ Those repos exist in source form, but they were not part of the deployed v5 ecos
   - `deployWith721sFor(...)` is gone.
   - `deployFor(...)` now returns the deployed `IJB721TiersHook`.
   - `REVOwner` is a new runtime address that integrators may need to track.
-  - `REVLoans.borrowFrom`, `reallocateCollateralFromLoan`, and `repayLoan` now accept a `holder`/`loanOwner` parameter for operator delegation via JBPermissions (IDs 37-39).
+  - `REVLoans.borrowFrom`, `reallocateCollateralFromLoan`, and `repayLoan` now accept a `holder`/`loanOwner` parameter for operator delegation via JBPermissions (IDs 36-38).
   - `REVLoans` no longer takes a `projects` constructor parameter.
 - `nana-omnichain-deployers-v6`
   - `launch721ProjectFor(...)`, `launch721RulesetsFor(...)`, and `queue721RulesetsOf(...)` collapsed into overloads using `JBOmnichain721Config`.
@@ -83,7 +83,7 @@ Those repos exist in source form, but they were not part of the deployed v5 ecos
 - `LAUNCH_RULESETS` is a new dedicated permission.
 - `SET_ROUTER_TERMINAL` replaces the old swap-terminal-specific permissions.
 - `SET_SUCKER_DEPRECATION` was split out from `SUCKER_SAFETY`.
-- `OPEN_LOAN` (37), `REALLOCATE_LOAN` (38), `REPAY_LOAN` (39) are new operator delegation permissions for `revnet-core-v6`.
+- `OPEN_LOAN` (36), `REALLOCATE_LOAN` (37), `REPAY_LOAN` (38) are new operator delegation permissions for `revnet-core-v6`.
 
 ## Excluded Repos
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,8 +71,7 @@ Those repos exist in source form, but they were not part of the deployed v5 ecos
   - `deployWith721sFor(...)` is gone.
   - `deployFor(...)` now returns the deployed `IJB721TiersHook`.
   - `REVOwner` is a new runtime address that integrators may need to track.
-  - `REVHiddenTokens` lets holders temporarily burn (hide) tokens to boost cash-out value, then re-mint (reveal) them later.
-  - `REVLoans.borrowFrom`, `reallocateCollateralFromLoan`, and `repayLoan` now accept a `holder`/`loanOwner` parameter for operator delegation via JBPermissions (IDs 35-39).
+  - `REVLoans.borrowFrom`, `reallocateCollateralFromLoan`, and `repayLoan` now accept a `holder`/`loanOwner` parameter for operator delegation via JBPermissions (IDs 37-39).
   - `REVLoans` no longer takes a `projects` constructor parameter.
 - `nana-omnichain-deployers-v6`
   - `launch721ProjectFor(...)`, `launch721RulesetsFor(...)`, and `queue721RulesetsOf(...)` collapsed into overloads using `JBOmnichain721Config`.
@@ -84,7 +83,7 @@ Those repos exist in source form, but they were not part of the deployed v5 ecos
 - `LAUNCH_RULESETS` is a new dedicated permission.
 - `SET_ROUTER_TERMINAL` replaces the old swap-terminal-specific permissions.
 - `SET_SUCKER_DEPRECATION` was split out from `SUCKER_SAFETY`.
-- `HIDE_TOKENS` (35), `OPEN_LOAN` (36), `REALLOCATE_LOAN` (37), `REPAY_LOAN` (38), `REVEAL_TOKENS` (39) are new operator delegation permissions for `revnet-core-v6`.
+- `OPEN_LOAN` (37), `REALLOCATE_LOAN` (38), `REPAY_LOAN` (39) are new operator delegation permissions for `revnet-core-v6`.
 
 ## Excluded Repos
 

--- a/RISKS.md
+++ b/RISKS.md
@@ -23,7 +23,7 @@ Primary repos and roles:
 - `nana-buyback-hook-v6`: buyback-vs-mint routing
 - `univ4-router-v6`: shared Uniswap V4 routing and oracle hook
 - `univ4-lp-split-hook-v6`: LP deployment and liquidity management
-- `revnet-core-v6`: revnet deployer, owner logic, loans, hidden tokens, fee handling
+- `revnet-core-v6`: revnet deployer, owner logic, loans, fee handling
 - `nana-suckers-v6`: cross-chain bridge and registry surfaces
 - `nana-omnichain-deployers-v6`: omnichain deployer logic
 - `nana-router-terminal-v6`: router terminal and registry

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -16,7 +16,7 @@
 | Multi-hop token routing, router-terminal previews, callback guards, or project-specific router overrides | [`nana-router-terminal-v6/SKILLS.md`](./nana-router-terminal-v6/SKILLS.md) |
 | ERC-20 voter rewards, 721 holder rewards, vesting rounds, or split-hook-funded distributions | [`nana-distributor-v6/SKILLS.md`](./nana-distributor-v6/SKILLS.md) |
 | Cross-chain token bridging, token mapping, Merkle roots, or chain-specific transport logic | [`nana-suckers-v6/SKILLS.md`](./nana-suckers-v6/SKILLS.md) |
-| Revnet deployment, staged issuance, ownerless runtime hooks, hidden tokens, or loans | [`revnet-core-v6/SKILLS.md`](./revnet-core-v6/SKILLS.md) |
+| Revnet deployment, staged issuance, ownerless runtime hooks, or loans | [`revnet-core-v6/SKILLS.md`](./revnet-core-v6/SKILLS.md) |
 | Omnichain project launch wrappers or deploying suckers together with 721 hooks | [`nana-omnichain-deployers-v6/SKILLS.md`](./nana-omnichain-deployers-v6/SKILLS.md) |
 | Full ecosystem deployment, resume flows, verification, or cross-package orchestration failures | [`deploy-all-v6/SKILLS.md`](./deploy-all-v6/SKILLS.md), [`nana-fee-project-deployer-v6/SKILLS.md`](./nana-fee-project-deployer-v6/SKILLS.md) |
 | V4 LP accumulation, burn-and-manage lifecycle, fee claims, or rebalancing | [`univ4-lp-split-hook-v6/SKILLS.md`](./univ4-lp-split-hook-v6/SKILLS.md) |

--- a/references/ecosystem-flows.md
+++ b/references/ecosystem-flows.md
@@ -30,8 +30,6 @@ Use this file when you need the fastest path from a user-facing flow or debuggin
 | Router cash-out recursion | `JBRouterTerminal._previewCashOutLoop()` / `_cashOutLoopOf()` | Iterates project-token cashouts until a terminal-accepted asset is found or routing continues |
 | V4 hook routing | `JBUniswapV4Hook._beforeSwap()` | Chooses JB vs V4 path, subject to preview availability and signed-delta limits |
 | Loan creation | `REVLoans.borrowFrom()` | Collateral lock, bonding curve valuation. Supports operator delegation via `holder` param (OPEN_LOAN permission). |
-| Hide tokens | `REVHiddenTokens.hideTokensOf()` | Burns tokens, tracks hidden balance. Reduces totalSupply, increases cash-out value for remaining holders. |
-| Reveal tokens | `REVHiddenTokens.revealTokensOf()` | Re-mints previously hidden tokens to beneficiary. |
 | Cross-chain prepare | `JBSucker.prepare()` | Cash out + insert into outbox merkle tree |
 | Cross-chain claim | `JBSucker.claim()` | Verify merkle proof + mint/transfer |
 | Cross-chain snapshot/root send | `JBSucker.toRemote()` / `_sendRoot()` | Drains outbox into a snapshot message and advances claim safety boundaries |

--- a/references/ecosystem-reference.md
+++ b/references/ecosystem-reference.md
@@ -35,7 +35,7 @@ Use this file after the workspace-level `SKILLS.md` has already routed you to th
 | `allowAddPriceFeed` | `bool` | |
 | `ownerMustSendPayouts` | `bool` | |
 | `holdFees` | `bool` | |
-| `useTotalSurplusForCashOuts` | `bool` | |
+| `scopeCashOutsToLocalBalances` | `bool` | When true, omnichain hooks use only local chain balances for cash outs |
 | `useDataHookForPay` | `bool` | |
 | `useDataHookForCashOut` | `bool` | |
 | `dataHook` | `address` | Data hook contract |
@@ -162,11 +162,9 @@ MAP_SUCKER_TOKEN         = 31    Map cross-chain tokens
 DEPLOY_SUCKERS           = 32    Deploy sucker pairs
 SUCKER_SAFETY            = 33    Emergency hatch control
 SET_SUCKER_DEPRECATION   = 34    Deprecate suckers
-HIDE_TOKENS              = 35    Hide tokens on behalf of holder (REVHiddenTokens)
-OPEN_LOAN                = 36    Open loan on behalf of holder (REVLoans)
-REALLOCATE_LOAN          = 37    Reallocate loan collateral on behalf of owner (REVLoans)
-REPAY_LOAN               = 38    Repay loan on behalf of owner (REVLoans)
-REVEAL_TOKENS            = 39    Reveal hidden tokens on behalf of holder (REVHiddenTokens)
+OPEN_LOAN                = 37    Open loan on behalf of holder (REVLoans)
+REALLOCATE_LOAN          = 38    Reallocate loan collateral on behalf of owner (REVLoans)
+REPAY_LOAN               = 39    Repay loan on behalf of owner (REVLoans)
 ```
 
 ## Libraries

--- a/references/ecosystem-reference.md
+++ b/references/ecosystem-reference.md
@@ -162,9 +162,9 @@ MAP_SUCKER_TOKEN         = 31    Map cross-chain tokens
 DEPLOY_SUCKERS           = 32    Deploy sucker pairs
 SUCKER_SAFETY            = 33    Emergency hatch control
 SET_SUCKER_DEPRECATION   = 34    Deprecate suckers
-OPEN_LOAN                = 37    Open loan on behalf of holder (REVLoans)
-REALLOCATE_LOAN          = 38    Reallocate loan collateral on behalf of owner (REVLoans)
-REPAY_LOAN               = 39    Repay loan on behalf of owner (REVLoans)
+OPEN_LOAN                = 36    Open loan on behalf of holder (REVLoans)
+REALLOCATE_LOAN          = 37    Reallocate loan collateral on behalf of owner (REVLoans)
+REPAY_LOAN               = 38    Repay loan on behalf of owner (REVLoans)
 ```
 
 ## Libraries


### PR DESCRIPTION
## Summary
- Update ecosystem documentation to reflect removal of the hidden tokens feature
- Remove HIDE_TOKENS and REVEAL_TOKENS from permission reference
- Remove hide/reveal token flows from ecosystem flows
- Update repo descriptions in ARCHITECTURE.md, RISKS.md, SKILLS.md, CHANGELOG.md

## Test plan
- [x] No remaining hidden tokens references in documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)