### PR TITLE
chore: refresh webclient references

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -30,7 +30,10 @@ This document covers the active EVM repos in `/v6/evm`:
 - `defifa`
 - `nana-fee-project-deployer-v6`
 - `deploy-all-v6`
-- `website`
+- `webclients/juicebox-money`
+- `webclients/revnet-money`
+- `webclients/juicy-vision`
+- `webclients/juicescan`
 
 ## Layers
 
@@ -64,7 +67,10 @@ Product / application layer
   -> banny-retail-v6
   -> defifa
   -> nana-fee-project-deployer-v6
-  -> website
+  -> webclients/juicebox-money
+  -> webclients/revnet-money
+  -> webclients/juicy-vision
+  -> webclients/juicescan
 ```
 
 Dependency direction matters:
@@ -212,7 +218,10 @@ If a bug crosses one of these seams, assume the blast radius may be larger than 
 | `defifa` | Prediction-game product with phased rulesets, scorecard governance, and game-piece cash-out logic |
 | `nana-fee-project-deployer-v6` | Deployment of the canonical protocol fee sink project |
 | `deploy-all-v6` | Canonical deployment, resume, and verification orchestration |
-| `website` | Canonical webapp reference for user-facing V6 flows, copy, warnings, and protocol affordances |
+| `webclients/juicebox-money` | Primary Juicebox Money application |
+| `webclients/revnet-money` | Revnet-focused application |
+| `webclients/juicy-vision` | Juicy Vision application and service client |
+| `webclients/juicescan` | Canonical webapp reference for user-facing V6 flows, copy, warnings, and protocol affordances |
 
 ## Common Compositions
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Use this README when you need to answer four questions quickly:
 - which directories are active workspace surfaces versus supporting material
 
 App: <https://juicebox.money>  
-Canonical webapp reference: [`website`](./website) ([mejango/juicebox-v6-website](https://github.com/mejango/juicebox-v6-website))  
+Canonical webapp reference: [`webclients/juicescan`](./webclients/juicescan) ([mejango/juicescan](https://github.com/mejango/juicescan))\
 Docs: <https://docs.juicebox.money>  
 Architecture: [ARCHITECTURE.md](./ARCHITECTURE.md)  
 User journeys: [USER_JOURNEYS.md](./USER_JOURNEYS.md)  
@@ -26,14 +26,14 @@ RISKS maintenance: [RISKS_MAINTENANCE.md](./RISKS_MAINTENANCE.md)
 
 This workspace contains:
 
-- active protocol and product repos at the top level
+- active protocol repos at the top level and application repos under [`webclients`](./webclients)
 - workspace-level guidance docs
 - templates under [`documentation_templates`](./documentation_templates)
 - maintenance notes under [`docs`](./docs)
 - archived packages under [`archive`](./archive)
 - audit artifacts and local tooling
 
-If you are tracing live behavior, start from active top-level repos, not `archive/`, templates, or old audit output.
+If you are tracing live behavior, start from an active protocol repo or an application under [`webclients`](./webclients), not `archive/`, templates, or old audit output.
 
 ## What This Workspace Contains
 
@@ -44,7 +44,7 @@ The V6 EVM surface is organized into a few recurring roles:
 - cross-chain repos move project tokens and reclaimed assets between chains
 - deployer repos package multi-contract compositions into launch surfaces
 - application repos build opinionated products on top of the shared protocol primitives
-- [`website`](./website) is the canonical webapp reference for how Juicebox V6 is presented and operated from the user-facing interface
+- [`webclients/juicescan`](./webclients/juicescan) is the canonical webapp reference for how Juicebox V6 is presented and operated from the user-facing interface
 
 The main reading rule is simple:
 
@@ -110,7 +110,7 @@ Start from the question you are trying to answer:
 - handles and naming: `nana-project-handles-v6`
 - reward distribution outside the main terminal path: `nana-distributor-v6`
 - deployment sequencing: `deploy-all-v6`
-- canonical webapp behavior, copy, and user-facing protocol affordances: `website`
+- canonical webapp behavior, copy, and user-facing protocol affordances: `webclients/juicescan`
 
 ## Common Reading Mistakes
 


### PR DESCRIPTION
## Summary
- point workspace documentation at the four `webclients/*` applications and renamed `mejango/juicescan` repository
- advance the Revnet Money submodule to the green dependency-security fix on main

## Verification
- no tracked parent documentation references the removed `website/` path or `juicebox-v6-website` repository
- Revnet Money CI passed at `2cdced4460a8a084467b2098b04f7e25a8843fcf` (audit, type/lint/tests/build/browser, and OCI smoke test)
- staged parent diff contains only `README.md`, `ARCHITECTURE.md`, and `webclients/revnet-money`